### PR TITLE
Allow user to set their online status

### DIFF
--- a/libmatrix.c
+++ b/libmatrix.c
@@ -64,11 +64,11 @@ static GList *matrixprpl_status_types(PurpleAccount *acct)
     PurpleStatusType *type;
 
     type = purple_status_type_new(PURPLE_STATUS_OFFLINE, "Offline", NULL,
-            FALSE);
+            TRUE);
     types = g_list_prepend(types, type);
 
     type = purple_status_type_new(PURPLE_STATUS_AVAILABLE, "Online", NULL,
-            FALSE);
+            TRUE);
     types = g_list_prepend(types, type);
 
     return types;


### PR DESCRIPTION
Without this change, the user can't pick Online/Offline from the status dropdown box to be able to login (if they start their client in offline mode) or to logout