### PR TITLE
Ignore empty m.room.name

### DIFF
--- a/matrix-statetable.c
+++ b/matrix-statetable.c
@@ -129,7 +129,7 @@ gchar *matrix_statetable_get_room_alias(MatrixRoomStateEventTable *state_table)
     if(event != NULL) {
         tmpname = matrix_json_object_get_string_member(
                 event->content, "name");
-        if(tmpname != NULL) {
+        if(tmpname != NULL && tmpname[0] != '\0') {
             return g_strdup(tmpname);
         }
     }


### PR DESCRIPTION
m.room.name can exist but be an empty string, in which case we
should fallback to one of the other naming schemes.

(#offtopic:matrix.org has this).

Signed-off-by: Dr. David Alan Gilbert <dave@treblig.org>