### PR TITLE
Send images

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -5,3 +5,5 @@ Eion Robb <eion at robbmob.com>
  * Windows build
  * Fix online/offline switch
 
+Dr. David Alan Gilbert <dave at treblig.org>
+ * Sending images, emote handling

--- a/libmatrix.c
+++ b/libmatrix.c
@@ -230,7 +230,6 @@ static char *matrixprpl_get_cb_real_name(PurpleConnection *gc, int id,
 }
 
 
-
 /******************************************************************************
  *
  * prpl stuff. see prpl.h for more information.
@@ -238,7 +237,8 @@ static char *matrixprpl_get_cb_real_name(PurpleConnection *gc, int id,
 
 static PurplePluginProtocolInfo prpl_info =
 {
-    OPT_PROTO_UNIQUE_CHATNAME | OPT_PROTO_CHAT_TOPIC,    /* options */
+    OPT_PROTO_UNIQUE_CHATNAME | OPT_PROTO_CHAT_TOPIC |
+      OPT_PROTO_IM_IMAGE,    /* options */
     NULL,               /* user_splits, initialized in matrixprpl_init() */
     NULL,               /* protocol_options, initialized in matrixprpl_init() */
     {   /* icon_spec, a PurpleBuddyIconSpec */

--- a/matrix-api.c
+++ b/matrix-api.c
@@ -390,10 +390,11 @@ static void _parse_url(const gchar *url, const gchar **host, const gchar **path)
  *   - libpurple's purple_url_parse assumes that the path + querystring is
  *     shorter than 256 bytes.
  *
- *  @returns a gchar* which should be freed
+ *  @returns a GString* which should be freed
  */
-static gchar *_build_request(PurpleAccount *acct, const gchar *url,
-        const gchar *method, const gchar *body)
+static GString *_build_request(PurpleAccount *acct, const gchar *url,
+        const gchar *method, const gchar *body,
+        const gchar *extra_data, gsize extra_len)
 {
     PurpleProxyInfo *gpi = purple_proxy_get_setup(acct);
     GString *request_str = g_string_new(NULL);
@@ -422,7 +423,7 @@ static gchar *_build_request(PurpleAccount *acct, const gchar *url,
 
     g_string_append(request_str, "Connection: close\r\n");
     g_string_append_printf(request_str, "Content-Length: %" G_GSIZE_FORMAT "\r\n",
-            body == NULL ? 0 : strlen(body));
+            extra_len + (body == NULL ? 0 : strlen(body)));
 
     if(using_http_proxy)
         _add_proxy_auth_headers(request_str, gpi);
@@ -431,30 +432,37 @@ static gchar *_build_request(PurpleAccount *acct, const gchar *url,
     if(body != NULL)
         g_string_append(request_str, body);
 
-    return g_string_free(request_str, FALSE);
+    if(extra_data != NULL)
+        g_string_append_len(request_str, extra_data, extra_len);
+
+    return request_str;
 }
 
 
 /**
  * Start an HTTP call to the API
  *
- * @param method  HTTP method (eg "GET")
- * @param body    body of request, or NULL if none
- * @param max_len maximum number of bytes to return from the request. -1 for
- *                default (512K).
+ * @param method      HTTP method (eg "GET")
+ * @param body        body of request, or NULL if none
+ * @param extra_data  raw binary data to be sent after the body
+ * @param extra_len   The length of the raw binary data
+ * @param max_len     maximum number of bytes to return from the request. -1 for
+ *                    default (512K).
  *
  * @returns handle for the request, or NULL if the request couldn't be started
  *   (eg, invalid hostname). In this case, the error_callback will have
  *   been called already.
  */
-static MatrixApiRequestData *matrix_api_start(const gchar *url,
-        const gchar *method, const gchar *body, MatrixConnectionData *conn,
+static MatrixApiRequestData *matrix_api_start_full(const gchar *url,
+        const gchar *method, const gchar *body,
+        const gchar *extra_data, gsize extra_len,
+        MatrixConnectionData *conn,
         MatrixApiCallback callback, MatrixApiErrorCallback error_callback,
         MatrixApiBadResponseCallback bad_response_callback,
         gpointer user_data, gssize max_len)
 {
     MatrixApiRequestData *data;
-    gchar *request;
+    GString *request;
     PurpleUtilFetchUrlData *purple_data;
 
     if (error_callback == NULL)
@@ -472,10 +480,11 @@ static MatrixApiRequestData *matrix_api_start(const gchar *url,
         return NULL;
     }
 
-    request = _build_request(conn->pc->account, url, method, body);
+    request = _build_request(conn->pc->account, url, method, body,
+                             extra_data, extra_len);
 
     if(purple_debug_is_unsafe())
-        purple_debug_info("matrixprpl", "request %s\n", request);
+        purple_debug_info("matrixprpl", "request %s\n", request->str);
 
 
     data = g_new0(MatrixApiRequestData, 1);
@@ -485,9 +494,10 @@ static MatrixApiRequestData *matrix_api_start(const gchar *url,
     data->bad_response_callback = bad_response_callback;
     data->user_data = user_data;
 
-    purple_data = purple_util_fetch_url_request_len_with_account(
+    purple_data = purple_util_fetch_url_request_data_len_with_account(
             conn -> pc -> account,
-            url, FALSE, NULL, TRUE, request, TRUE, max_len, matrix_api_complete,
+            url, FALSE, NULL, TRUE, request->str, request->len,
+            TRUE, max_len, matrix_api_complete,
             data);
 
     if(purple_data == NULL) {
@@ -499,8 +509,34 @@ static MatrixApiRequestData *matrix_api_start(const gchar *url,
         data->purple_data = purple_data;
     }
 
-    g_free(request);
+    g_string_free(request, TRUE);
     return data;
+}
+
+
+/**
+ * Start an HTTP call to the API; lighter version of matrix_api_start_full
+ * since most callers don't need the extras.
+ *
+ * @param method      HTTP method (eg "GET")
+ * @param body        body of request, or NULL if none
+ * @param max_len     maximum number of bytes to return from the request. -1 for
+ *                    default (512K).
+ *
+ * @returns handle for the request, or NULL if the request couldn't be started
+ *   (eg, invalid hostname). In this case, the error_callback will have
+ *   been called already.
+ */
+static MatrixApiRequestData *matrix_api_start(const gchar *url,
+        const gchar *method, const gchar *body,
+        MatrixConnectionData *conn,
+        MatrixApiCallback callback, MatrixApiErrorCallback error_callback,
+        MatrixApiBadResponseCallback bad_response_callback,
+        gpointer user_data, gssize max_len)
+{
+    return matrix_api_start_full(url, method, body, NULL, 0, conn,
+            callback, error_callback, bad_response_callback,
+            user_data, max_len);
 }
 
 

--- a/matrix-api.c
+++ b/matrix-api.c
@@ -742,6 +742,43 @@ MatrixApiRequestData *matrix_api_leave_room(MatrixConnectionData *conn,
     return fetch_data;
 }
 
+/**
+ * Upload a file
+ *
+ * @param conn             The connection with which to make the request
+ * @param ctype            Content type of file
+ * @param data             Raw data content of file
+ * @param data_len         Length of the data
+ * @param callback         Function to be called when the request completes
+ * @param user_data        Opaque data to be passed to the callback
+ */
+MatrixApiRequestData *matrix_api_upload_file(MatrixConnectionData *conn,
+        const gchar *ctype, const gchar *data, gsize data_len,
+        MatrixApiCallback callback,
+        MatrixApiErrorCallback error_callback,
+        MatrixApiBadResponseCallback bad_response_callback,
+        gpointer user_data)
+{
+    GString *url, *extra_header;
+    MatrixApiRequestData *fetch_data;
+
+    url = g_string_new(conn->homeserver);
+    g_string_append(url, "/_matrix/media/r0/upload");
+    g_string_append(url, "/join?access_token=");
+    g_string_append(url, purple_url_encode(conn->access_token));
+
+    extra_header = g_string_new("Content-Type: ");
+    g_string_append(extra_header, ctype);
+    g_string_append(extra_header, "\r\n");
+
+    fetch_data = matrix_api_start_full(url->str, "POST", extra_header->str, "",
+            data, data_len, conn,
+            callback, error_callback, bad_response_callback, user_data, 0);
+    g_string_free(url, TRUE);
+    g_string_free(extra_header, TRUE);
+
+    return fetch_data;
+}
 
 #if 0
 MatrixApiRequestData *matrix_api_get_room_state(MatrixConnectionData *conn,

--- a/matrix-api.h
+++ b/matrix-api.h
@@ -227,6 +227,26 @@ MatrixApiRequestData *matrix_api_leave_room(MatrixConnectionData *conn,
         gpointer user_data);
 
 
+/**
+ * Upload a file
+ *
+ * @param conn             The connection with which to make the request
+ * @param ctype            Content type of file
+ * @param data             Raw data content of file
+ * @param data_len         Length of the data
+ * @param callback         Function to be called when the request completes
+ * @param user_data        Opaque data to be passed to the callback
+ */
+MatrixApiRequestData *matrix_api_upload_file(MatrixConnectionData *conn,
+        const gchar *ctype,
+        const gchar *data,
+        gsize data_len,
+        MatrixApiCallback callback,
+        MatrixApiErrorCallback error_callback,
+        MatrixApiBadResponseCallback bad_response_callback,
+        gpointer user_data);
+
+
 #if 0
 /**
  * Get the current state of a room

--- a/matrix-event.c
+++ b/matrix-event.c
@@ -50,5 +50,8 @@ void matrix_event_free(MatrixRoomEvent *event)
     g_free(event->txn_id);
     g_free(event->sender);
     g_free(event->event_type);
+    if (event->hook) {
+        event->hook(event, TRUE);
+    }
     g_free(event);
 }

--- a/matrix-event.h
+++ b/matrix-event.h
@@ -25,7 +25,14 @@
 #include <glib.h>
 
 struct _JsonObject;
+struct _MatrixRoomEvent;
 
+/* Callback by events;
+ * called with 'just_free' false prior to sending an event.
+ * called with 'just_free' true when freeing the event.
+ */
+typedef void (*EventSendHook)(struct _MatrixRoomEvent *event,
+        gboolean just_free);
 typedef struct _MatrixRoomEvent {
     /* for outgoing events, our made-up transaction id. NULL for incoming
      * events.
@@ -37,6 +44,14 @@ typedef struct _MatrixRoomEvent {
 
     gchar *event_type;
     struct _JsonObject *content;
+
+    /* Hook (& data) called when the event is unqueued; the hook should
+     * do the send itself.
+     * Useful where a file has to be uploaded before sending the event.
+     */
+    EventSendHook hook;
+
+    void *hook_data;
 } MatrixRoomEvent;
 
 

--- a/matrix-room.c
+++ b/matrix-room.c
@@ -350,6 +350,158 @@ void _event_send_bad_response(MatrixConnectionData *ma, gpointer user_data,
     /* for now, we leave the message queued. We should consider retrying. */
 }
 
+/**************************** Image handling *********************************/
+/* Data structure passed from the event hook to the upload completion */
+struct SendImageEventData {
+    PurpleConversation *conv;
+    MatrixRoomEvent *event;
+    int imgstore_id;
+};
+
+/**
+ * Called back by matrix_api_upload_file after the image is uploaded.
+ * We get a 'content_uri' identifying the uploaded file, and that's what
+ * we put in the event.
+ */
+static void _image_upload_complete(MatrixConnectionData *ma,
+      gpointer user_data, JsonNode *json_root)
+{
+    MatrixApiRequestData *fetch_data = NULL;
+    struct SendImageEventData *sied = user_data;
+    JsonObject *response_object = matrix_json_node_get_object(json_root);
+    const gchar *content_uri;
+    PurpleStoredImage *image = purple_imgstore_find_by_id(sied->imgstore_id);
+
+    content_uri = matrix_json_object_get_string_member(response_object,
+            "content_uri");
+    if (content_uri == NULL) {
+        matrix_api_error(ma, sied->conv,
+                "image_upload_complete: no content_uri");
+        purple_imgstore_unref(image);
+        g_free(sied);
+        return;
+    }
+
+    json_object_set_string_member(sied->event->content, "url", content_uri);
+
+    fetch_data = matrix_api_send(ma, sied->conv->name, sied->event->event_type,
+             sied->event->txn_id, sied->event->content, _event_send_complete,
+             _event_send_error, _event_send_bad_response, sied->conv);
+    purple_conversation_set_data(sied->conv, PURPLE_CONV_DATA_ACTIVE_SEND,
+                    fetch_data);
+    purple_imgstore_unref(image);
+    g_free(sied);
+}
+
+static void _image_upload_bad_response(MatrixConnectionData *ma, gpointer user_data,
+            int http_response_code, JsonNode *json_root)
+{
+    struct SendImageEventData *sied = user_data;
+    PurpleStoredImage *image = purple_imgstore_find_by_id(sied->imgstore_id);
+
+    matrix_api_bad_response(ma, sied->conv, http_response_code, json_root);
+    purple_imgstore_unref(image);
+    purple_conversation_set_data(sied->conv, PURPLE_CONV_DATA_ACTIVE_SEND,
+            NULL);
+    g_free(sied);
+    /* More clear up with the message? */
+}
+
+void _image_upload_error(MatrixConnectionData *ma, gpointer user_data,
+            const gchar *error_message)
+{
+    struct SendImageEventData *sied = user_data;
+    PurpleStoredImage *image = purple_imgstore_find_by_id(sied->imgstore_id);
+
+    matrix_api_error(ma, sied->conv, error_message);
+    purple_imgstore_unref(image);
+    purple_conversation_set_data(sied->conv, PURPLE_CONV_DATA_ACTIVE_SEND,
+            NULL);
+    g_free(sied);
+    /* More clear up with the message? */
+}
+
+/**
+ * Return a mimetype based on some info; this should get replaced
+ * with a glib/gio/gcontent_type_guess call if we can include it,
+ * all other plugins do this manually.
+ */
+static const char *type_guess(PurpleStoredImage *image)
+{
+    /* Copied off the code in libpurple's jabber module */
+    const char *ext = purple_imgstore_get_extension(image);
+
+    if (strcmp(ext, "png") == 0) {
+      return "image/png";
+    } else if (strcmp(ext, "gif") == 0) {
+      return "image/gif";
+    } else if (strcmp(ext, "jpg") == 0) {
+      return "image/jpeg";
+    } else if (strcmp(ext, "tif") == 0) {
+      return "image/tif";
+    } else {
+      return "image/x-icon"; /* or something... */
+    }
+}
+
+/* Structure hung off the event and used by _send_image_hook */
+struct SendImageHookData {
+    PurpleConversation *conv;
+    int imgstore_id;
+};
+/**
+ * Called back by _send_queued_event for an image.
+ */
+static void _send_image_hook(MatrixRoomEvent *event, gboolean just_free)
+{
+    MatrixApiRequestData *fetch_data;
+    struct SendImageHookData *sihd = event->hook_data;
+    /* Free'd by the callbacks from upload_file */
+    struct SendImageEventData *sied = g_new0(struct SendImageEventData, 1);
+    PurpleConnection *pc;
+    MatrixConnectionData *acct;
+    int imgstore_id;
+    PurpleStoredImage *image;
+    size_t imgsize;
+    const char *filename;
+    const char *ctype;
+    gconstpointer imgdata;
+
+    if (just_free) {
+        g_free(event->hook_data);
+        return;
+    }
+
+    pc = sihd->conv->account->gc;
+    acct = purple_connection_get_protocol_data(pc);
+    imgstore_id = sihd->imgstore_id;
+    image = purple_imgstore_find_by_id(imgstore_id);
+    if (!image)
+        return;
+
+    imgsize = purple_imgstore_get_size(image);
+    filename = purple_imgstore_get_filename(image);
+    imgdata = purple_imgstore_get_data(image);
+    ctype = type_guess(image);
+
+    purple_debug_info("matrixprpl", "%s: image id %d for %s (type: %s)\n",
+            __func__,
+            sihd->imgstore_id, filename, ctype);
+
+    sied->conv = sihd->conv;
+    sied->imgstore_id = sihd->imgstore_id;
+    sied->event = event;
+    json_object_set_string_member(event->content, "body", filename);
+
+    fetch_data = matrix_api_upload_file(acct, ctype, imgdata, imgsize,
+                           _image_upload_complete,
+                           _image_upload_error,
+                           _image_upload_bad_response, sied);
+    purple_conversation_set_data(sied->conv, PURPLE_CONV_DATA_ACTIVE_SEND,
+            fetch_data);
+}
+
+
 /**
  * send the next queued event, provided the connection isn't shutting down.
  *
@@ -791,6 +943,41 @@ static const gchar *_get_my_display_name(PurpleConversation *conv)
 }
 
 /**
+ * Send an image message in a room
+ */
+void matrix_room_send_image(PurpleConversation *conv, int imgstore_id,
+        const gchar *message)
+{
+    JsonObject *content;
+    struct SendImageHookData *sihd;
+
+    if (!imgstore_id)
+        return;
+    /* This is the hook_data on the event, it gets free'd by the event
+     * code when the event is free'd
+     */
+    sihd = g_new0(struct SendImageHookData, 1);
+
+    /* We can't send this event until we've uploaded the image because
+     * the event contents including the file ID that we get back from
+     * the upload process.
+     * Our hook gets called back when we're ready to send the event,
+     * then we do the upload.
+     */
+    content = json_object_new();
+    json_object_set_string_member(content, "msgtype", "m.image");
+
+    sihd->imgstore_id = imgstore_id;
+    sihd->conv = conv;
+    purple_debug_info("matrixprpl", "%s: image id=%d\n", __func__, imgstore_id);
+    _enqueue_event(conv, "m.room.message", content, _send_image_hook, sihd);
+    json_object_unref(content);
+    purple_conv_chat_write(PURPLE_CONV_CHAT(conv), _get_my_display_name(conv),
+            message, PURPLE_MESSAGE_SEND | PURPLE_MESSAGE_IMAGES,
+            g_get_real_time()/1000/1000);
+}
+
+/**
  * Send a message in a room
  */
 void matrix_room_send_message(PurpleConversation *conv, const gchar *message)
@@ -799,6 +986,37 @@ void matrix_room_send_message(PurpleConversation *conv, const gchar *message)
     PurpleConvChat *chat = PURPLE_CONV_CHAT(conv);
     const char *type_string = "m.text";
     const gchar *message_to_send = message;
+    const char *image_start, *image_end;
+    GData *image_attribs;
+
+    /* Matrix doesn't have messages that have both images and text in, so
+     * we have to split this message if it has an image.
+     */
+    if (purple_markup_find_tag("img", message,
+                               &image_start,
+                               &image_end,
+                               &image_attribs)) {
+        int imgstore_id = atoi(g_datalist_get_data(&image_attribs, "id"));
+        gchar *image_message;
+        purple_imgstore_ref_by_id(imgstore_id);
+
+        if (image_start != message) {
+            gchar *prefix = g_strndup(message, image_start - message);
+            matrix_room_send_message(conv, prefix);
+            g_free(prefix);
+        }
+
+        image_message = g_strndup(image_start, 1+(image_end-image_start));
+        matrix_room_send_image(conv, imgstore_id, image_message);
+        g_datalist_clear(&image_attribs);
+        g_free(image_message);
+
+        /* Anything after the image? */
+        if (image_end[1]) {
+            matrix_room_send_message(conv, image_end + 1);
+        }
+        return;
+    }
 
     if (!strncmp(message, "/me ", 4)) {
         type_string = "m.emote";


### PR DESCRIPTION
This set adds the ability to use 'insert images' in pidgin; it seems to work OK, it gets a little complicated by the way purple has messages containing both text and images where Matrix has either text events or image events.