### PR TITLE
Allow building on libpurple 2.10.x

### DIFF
--- a/matrix-room.c
+++ b/matrix-room.c
@@ -497,8 +497,10 @@ static void _send_image_hook(MatrixRoomEvent *event, gboolean just_free)
                            _image_upload_complete,
                            _image_upload_error,
                            _image_upload_bad_response, sied);
-    purple_conversation_set_data(sied->conv, PURPLE_CONV_DATA_ACTIVE_SEND,
-            fetch_data);
+    if (fetch_data) {
+        purple_conversation_set_data(sied->conv, PURPLE_CONV_DATA_ACTIVE_SEND,
+                fetch_data);
+    }
 }
 
 


### PR DESCRIPTION
 In 2f143058d I used the purple_util_fetch_url_request_data_len_with_account
which turns out to be new in libpurple 2.11 and ubuntu is still
stuck on 2.10.

This is a build hack that allows building on 2.10 but doesn't
allow sending images.

Signed-off-by: Dr. David Alan Gilbert <dave@treblig.org>