### PR TITLE
build: don't add -O0 and -Werror

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -2,7 +2,7 @@
 
 COMPILE.c = $(CC) $(CFLAGS) $(CPPFLAGS) $(TARGET_ARCH) -c
 
-CFLAGS+=-Wall -g -O0 -Werror
+CFLAGS += -Wall -g
 CFLAGS += -DPURPLE_PLUGINS 
 
 # generate .d files when compiling


### PR DESCRIPTION
It's worst idea to make all warnings as errors. For example,
it's even conflicting with -O0:
```c
gcc -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -m64 -mtune=generic -DPURPLE_PLUGINS -pthread -I/usr/include/libpurple -I/usr/include/json-glib-1.0 -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -fPIC -DPIC -Wall -g -O0 -Werror -MMD  -c -o libmatrix.o libmatrix.c
In file included from /usr/include/bits/libc-header-start.h:33:0,
                 from /usr/include/limits.h:26,
                 from /usr/lib/gcc/x86_64-redhat-linux/6.2.1/include/limits.h:168,
                 from /usr/lib/gcc/x86_64-redhat-linux/6.2.1/include/syslimits.h:7,
                 from /usr/lib/gcc/x86_64-redhat-linux/6.2.1/include/limits.h:34,
                 from /usr/lib64/glib-2.0/include/glibconfig.h:11,
                 from /usr/include/glib-2.0/glib/gtypes.h:32,
                 from /usr/include/glib-2.0/glib/galloca.h:32,
                 from /usr/include/glib-2.0/glib.h:30,
                 from libmatrix.h:96,
                 from libmatrix.c:25:
/usr/include/features.h:373:4: error: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Werror=cpp]
 #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
    ^~~~~~~
```