### PR TITLE
Re-use the device-id provided by the server

### DIFF
--- a/matrix-api.c
+++ b/matrix-api.c
@@ -585,7 +585,7 @@ void matrix_api_cancel(MatrixApiRequestData *data)
 }
 
 
-gchar *_build_login_body(const gchar *username, const gchar *password)
+gchar *_build_login_body(const gchar *username, const gchar *password, const gchar *device_id)
 {
     JsonObject *body;
     JsonNode *node;
@@ -596,7 +596,10 @@ gchar *_build_login_body(const gchar *username, const gchar *password)
     json_object_set_string_member(body, "type", "m.login.password");
     json_object_set_string_member(body, "user", username);
     json_object_set_string_member(body, "password", password);
-	
+    json_object_set_string_member(body, "initial_device_display_name", "purple-matrix");
+    if (device_id != NULL)
+        json_object_set_string_member(body, "device_id", device_id);
+    
     node = json_node_new(JSON_NODE_OBJECT);
     json_node_set_object(node, body);
     json_object_unref(body);
@@ -612,6 +615,7 @@ gchar *_build_login_body(const gchar *username, const gchar *password)
 MatrixApiRequestData *matrix_api_password_login(MatrixConnectionData *conn,
         const gchar *username,
         const gchar *password,
+        const gchar *device_id,
         MatrixApiCallback callback,
         gpointer user_data)
 {
@@ -625,7 +629,7 @@ MatrixApiRequestData *matrix_api_password_login(MatrixConnectionData *conn,
     url = g_strconcat(conn->homeserver, "_matrix/client/api/v1/login",
             NULL);
 
-    json = _build_login_body(username, password);
+    json = _build_login_body(username, password, device_id);
 
     fetch_data = matrix_api_start(url, "POST", json, conn, callback,
             NULL, NULL, user_data, 0);

--- a/matrix-api.h
+++ b/matrix-api.h
@@ -134,6 +134,7 @@ void matrix_api_cancel(MatrixApiRequestData *request);
 MatrixApiRequestData *matrix_api_password_login(MatrixConnectionData *conn,
         const gchar *username,
         const gchar *password,
+        const gchar *device_id,
         MatrixApiCallback callback,
         gpointer user_data);
 

--- a/matrix-connection.c
+++ b/matrix-connection.c
@@ -181,6 +181,8 @@ static void _login_completed(MatrixConnectionData *conn,
     conn->access_token = g_strdup(access_token);
     conn->user_id = g_strdup(matrix_json_object_get_string_member(root_obj,
             "user_id"));
+    purple_account_set_string(pc->account, "device_id", 
+        matrix_json_object_get_string_member(root_obj, "device_id"));
 
     /* start the sync loop */
     next_batch = purple_account_get_string(pc->account,
@@ -233,7 +235,9 @@ void matrix_connection_start_login(PurpleConnection *pc)
     purple_connection_update_progress(pc, _("Logging in"), 0, 3);
 
     matrix_api_password_login(conn, acct->username,
-            purple_account_get_password(acct), _login_completed, conn);
+            purple_account_get_password(acct),
+            purple_account_get_string(acct, "device_id", NULL),
+            _login_completed, conn);
 }
 
 


### PR DESCRIPTION
Re-use the device-id provided by the server so we don't show up once for each login. Cleans up the "Devices" list visible in Riot.im settings

Signed-off-by: Eion Robb <eion@robbmob.com>