### PR TITLE
Fix image download

### DIFF
--- a/matrix-api.c
+++ b/matrix-api.c
@@ -875,10 +875,8 @@ MatrixApiRequestData *matrix_api_download_file(MatrixConnectionData *conn,
         return NULL;
     }
     url = g_string_new(conn->homeserver);
-    g_string_append(url, "/_matrix/media/r0/download/");
+    g_string_append(url, "_matrix/media/r0/download/");
     g_string_append(url, uri + 6); /* i.e. after the mxc:// */
-    g_string_append(url, "?access_token=");
-    g_string_append(url, purple_url_encode(conn->access_token));
 
     /* I'd like to validate the headers etc a bit before downloading the
      * data (maybe using _handle_header_completed), also I'm not convinced


### PR DESCRIPTION
I had an extra / after the hostname, and it doesn't need the access
key.
(Interestingly my server would take the extra / but matrix.org wouldn't)

Signed-off-by: Dr. David Alan Gilbert <dave@treblig.org>