### PR TITLE
Fix image upload

### DIFF
--- a/matrix-api.c
+++ b/matrix-api.c
@@ -837,7 +837,7 @@ MatrixApiRequestData *matrix_api_upload_file(MatrixConnectionData *conn,
     MatrixApiRequestData *fetch_data;
 
     url = g_string_new(conn->homeserver);
-    g_string_append(url, "/_matrix/media/r0/upload");
+    g_string_append(url, "_matrix/media/r0/upload");
     g_string_append(url, "?access_token=");
     g_string_append(url, purple_url_encode(conn->access_token));
 


### PR DESCRIPTION
I made the same mistake in image upload I had in download - an extra /
at the start triggered a 500.

Signed-off-by: Dr. David Alan Gilbert <dave@treblig.org>