### PR TITLE
Support HTML formatting on sending/receiving messages

### DIFF
--- a/libmatrix.c
+++ b/libmatrix.c
@@ -84,7 +84,7 @@ void matrixprpl_login(PurpleAccount *acct)
     matrix_connection_new(pc);
     matrix_connection_start_login(pc);
     
-	pc->flags |= PURPLE_CONNECTION_HTML;
+    pc->flags |= PURPLE_CONNECTION_HTML;
 }
 
 

--- a/libmatrix.c
+++ b/libmatrix.c
@@ -83,6 +83,8 @@ void matrixprpl_login(PurpleAccount *acct)
     PurpleConnection *pc = purple_account_get_connection(acct);
     matrix_connection_new(pc);
     matrix_connection_start_login(pc);
+    
+	pc->flags |= PURPLE_CONNECTION_HTML;
 }
 
 

--- a/matrix-room.c
+++ b/matrix-room.c
@@ -872,12 +872,12 @@ void matrix_room_handle_timeline_event(PurpleConversation *conv,
     }
     flags = PURPLE_MESSAGE_RECV;
 
-	if (purple_strequal(matrix_json_object_get_string_member(json_content_obj, "format"), "org.matrix.custom.html")) {
-		escaped_body = g_strdup(matrix_json_object_get_string_member(json_content_obj, "formatted_body"));
-	} else {
-		escaped_body = purple_markup_escape_text(tmp_body ? tmp_body : msg_body, -1);
-	}
-	g_free(tmp_body);
+    if (purple_strequal(matrix_json_object_get_string_member(json_content_obj, "format"), "org.matrix.custom.html")) {
+        escaped_body = g_strdup(matrix_json_object_get_string_member(json_content_obj, "formatted_body"));
+    } else {
+        escaped_body = purple_markup_escape_text(tmp_body ? tmp_body : msg_body, -1);
+    }
+    g_free(tmp_body);
     purple_debug_info("matrixprpl", "got message from %s in %s\n", sender_id,
             room_id);
     serv_got_chat_in(conv->account->gc, g_str_hash(room_id),
@@ -1227,12 +1227,12 @@ void matrix_room_send_message(PurpleConversation *conv, const gchar *message)
      * escape the message body. Matrix clients don't unescape the bodies
      * either, so they end up seeing &quot; instead of "
      */
-	message_dup = g_strdup(message);
+    message_dup = g_strdup(message);
     message_to_send = purple_markup_strip_html(message_dup);
 
     if (purple_message_meify(message_to_send, -1)) {
         type_string = "m.emote";
-		purple_message_meify(message_dup, -1);
+        purple_message_meify(message_dup, -1);
     }
 
     content = json_object_new();
@@ -1246,5 +1246,7 @@ void matrix_room_send_message(PurpleConversation *conv, const gchar *message)
 
     purple_conv_chat_write(chat, _get_my_display_name(conv),
             message_dup, PURPLE_MESSAGE_SEND, g_get_real_time()/1000/1000);
+
     g_free(message_to_send);
+    g_free(message_dup);
 }

--- a/matrix-room.c
+++ b/matrix-room.c
@@ -872,8 +872,12 @@ void matrix_room_handle_timeline_event(PurpleConversation *conv,
     }
     flags = PURPLE_MESSAGE_RECV;
 
-    escaped_body = purple_markup_escape_text(tmp_body ? tmp_body : msg_body, -1);
-    g_free(tmp_body);
+	if (purple_strequal(matrix_json_object_get_string_member(json_content_obj, "format"), "org.matrix.custom.html")) {
+		escaped_body = g_strdup(matrix_json_object_get_string_member(json_content_obj, "formatted_body"));
+	} else {
+		escaped_body = purple_markup_escape_text(tmp_body ? tmp_body : msg_body, -1);
+	}
+	g_free(tmp_body);
     purple_debug_info("matrixprpl", "got message from %s in %s\n", sender_id,
             room_id);
     serv_got_chat_in(conv->account->gc, g_str_hash(room_id),
@@ -1187,7 +1191,7 @@ void matrix_room_send_message(PurpleConversation *conv, const gchar *message)
     PurpleConvChat *chat = PURPLE_CONV_CHAT(conv);
     const char *type_string = "m.text";
     const char *image_start, *image_end;
-    gchar *message_to_send;
+    gchar *message_to_send, *message_dup;
     GData *image_attribs;
 
     /* Matrix doesn't have messages that have both images and text in, so
@@ -1223,20 +1227,24 @@ void matrix_room_send_message(PurpleConversation *conv, const gchar *message)
      * escape the message body. Matrix clients don't unescape the bodies
      * either, so they end up seeing &quot; instead of "
      */
-    message_to_send = purple_unescape_html(message);
+	message_dup = g_strdup(message);
+    message_to_send = purple_markup_strip_html(message_dup);
 
     if (purple_message_meify(message_to_send, -1)) {
         type_string = "m.emote";
+		purple_message_meify(message_dup, -1);
     }
 
     content = json_object_new();
     json_object_set_string_member(content, "msgtype", type_string);
     json_object_set_string_member(content, "body", message_to_send);
+    json_object_set_string_member(content, "formatted_body", message_dup);
+    json_object_set_string_member(content, "format", "org.matrix.custom.html");
 
     _enqueue_event(conv, "m.room.message", content, NULL, NULL);
     json_object_unref(content);
 
     purple_conv_chat_write(chat, _get_my_display_name(conv),
-            message, PURPLE_MESSAGE_SEND, g_get_real_time()/1000/1000);
+            message_dup, PURPLE_MESSAGE_SEND, g_get_real_time()/1000/1000);
     g_free(message_to_send);
 }


### PR DESCRIPTION
* Supports sending/receiving HTML formatting using the `org.matrix.custom.html` format
* Fixes unstripped `<font>` tags being sent by Pidgin when copy-pasting content into the messaging window
* Pidgin sends html colours with hex codes, however the irc bridge expects colour names, so colours do not currently pass through to IRC correctly

Signed-off-by: Eion Robb <eion@robbmob.com>