### PR TITLE
bump up max reply size

### DIFF
--- a/matrix-api.c
+++ b/matrix-api.c
@@ -668,7 +668,7 @@ MatrixApiRequestData *matrix_api_sync(MatrixConnectionData *conn,
      * memory? But it's JSON
      */
     fetch_data = matrix_api_start(url->str, "GET", NULL, conn, callback,
-            error_callback, bad_response_callback, user_data, 10*1024*1024);
+            error_callback, bad_response_callback, user_data, 40*1024*1024);
     g_string_free(url, TRUE);
     
     return fetch_data;


### PR DESCRIPTION
Initial sync's are getting huge, we really need to fix that,
but in the mean time bump the max size up.
I've seen matrix HQ giving out a 5MB reply in the initial sync.

see issue #28.

Signed-off-by: Dr. David Alan Gilbert <dave@treblig.org>