### PR TITLE
[Makefile] Change fixed pkg-config into variable PKG_CONFIG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ LIBS=purple json-glib-1.0 glib-2.0
 PKG_CONFIG=pkg-config
 CFLAGS+=$(shell $(PKG_CONFIG) --cflags $(LIBS))
 CFLAGS+=-fPIC -DPIC
-LDLIBS+=$(shell pkg-config --libs $(LIBS))
+LDLIBS+=$(shell $(PKG_CONFIG) --libs $(LIBS))
 LDLIBS+=-lhttp_parser
 
 PLUGIN_DIR_PURPLE	=  $(shell $(PKG_CONFIG) --variable=plugindir purple)


### PR DESCRIPTION
Change the LDLIBS line to be like the CFLAGS one with a variable PKG_CONFIG instead of the fixed pkg-config.