### PR TITLE
e2e: Link with libgcrypt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ LDLIBS+=$(shell $(PKG_CONFIG) --libs $(LIBS))
 LDLIBS+=-lhttp_parser
 
 ifndef MATRIX_NO_E2E
-LDLIBS+=-lolm
+LDLIBS+=-lolm -lgcrypt
 endif
 
 PLUGIN_DIR_PURPLE	=  $(shell $(PKG_CONFIG) --variable=plugindir purple)

--- a/Makefile.mingw
+++ b/Makefile.mingw
@@ -14,8 +14,9 @@ LDLIBS += -L$(HTTP_PARSER_TOP) -lhttp_parser -static-libgcc
 
 ifndef MATRIX_NO_E2E
 OLM_TOP ?= $(WIN32_DEV_TOP)/olm
-CFLAGS +=  -I$(OLM_TOP)/include
-LDLIBS+= -L$(OLM_TOP)/build -lolm
+GCRYPT_TOP ?= $(WIN32_DEV_TOP)/libgcrypt
+CFLAGS += -I$(OLM_TOP)/include -I$(GCRYPT_TOP)/src
+LDLIBS += -L$(OLM_TOP)/build -lolm -L$(GCRYPT_TOP)/bin -lgcrypt
 endif
 
 


### PR DESCRIPTION
Link with libgcrypt when e2e is enabled.
Build for Windows is not tested.

Fixes #83