### PR TITLE
Do not include gcrypt.h in matrix-room.c

### DIFF
--- a/matrix-room.c
+++ b/matrix-room.c
@@ -37,8 +37,6 @@
 #include "matrix-roommembers.h"
 #include "matrix-statetable.h"
 
-#include <gcrypt.h>
-
 
 static gchar *_get_room_name(MatrixConnectionData *conn,
         PurpleConversation *conv);


### PR DESCRIPTION
Nothing from gcrypt is used in matrix-room.c.