### PR TITLE
Make it clear that decryption is supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ The following are not yet supported:
  * Account registration
  * Room topics
  * Voice/video calling
+ 
+The following are in progress:
  * End-To-End encryption via Olm ([ticket](https://github.com/matrix-org/purple-matrix/issues/18))
+   * [Decyption is supported but not encryption](https://github.com/matrix-org/purple-matrix/issues/18#issuecomment-410336278)
 
 The plugin requires a matrix homeserver supporting client-server API r0.0.0 Synapse
 v0.12.0-rc1 or later is sufficient.


### PR DESCRIPTION
Signed-off-by: Aaron Raimist <aaron@raim.ist>

README isn't very clear that decryption is supported but encryption is not. Got reports that someone was able to decrypt messages in pidgin and thought everyone thought that encryption was broken for a second. https://matrix.to/#/!iNmaIQExDMeqdITdHH:matrix.org/$15487094581170217pdtaL:matrix.org?via=matrix.org&via=linuxgaming.life&via=disroot.org