### PR TITLE
Login updates: Avoid the outdated login API and store access tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ You will then need to restart Pidgin, after which you should be able to add a
   from the 'Protocol' dropdown.
 * Enter your matrix ID on the homeserver (e.g. '@bob:matrix.org' or 'bob') as
   the 'username', and the password in the 'password' field.
+  * If you don't enter your password, you'll be prompted for it when you try
+    to connect;  this won't get saved unless you click 'save password' but an
+    access token is stored instead.
 * On the 'Advanced' tab, enter the URL of your homeserver.
 
 

--- a/libmatrix.c
+++ b/libmatrix.c
@@ -272,6 +272,7 @@ static char *matrixprpl_get_cb_real_name(PurpleConnection *gc, int id,
 static PurplePluginProtocolInfo prpl_info =
 {
     OPT_PROTO_UNIQUE_CHATNAME | OPT_PROTO_CHAT_TOPIC |
+      OPT_PROTO_PASSWORD_OPTIONAL |
       OPT_PROTO_IM_IMAGE,    /* options */
     NULL,               /* user_splits, initialized in matrixprpl_init() */
     NULL,               /* protocol_options, initialized in matrixprpl_init() */

--- a/libmatrix.h
+++ b/libmatrix.h
@@ -117,6 +117,8 @@
 #define PRPL_ACCOUNT_OPT_SKIP_OLD_MESSAGES "skip_old_messages"
 /* Pickled account info from olm_pickle_account */
 #define PRPL_ACCOUNT_OPT_OLM_ACCOUNT_KEYS "olm_account_keys"
+/* Access token, after a login */
+#define PRPL_ACCOUNT_OPT_ACCESS_TOKEN "access_token"
 
 /* defaults for account options */
 #define DEFAULT_HOME_SERVER "https://matrix.org"

--- a/matrix-api.c
+++ b/matrix-api.c
@@ -1011,6 +1011,31 @@ MatrixApiRequestData *matrix_api_download_thumb(MatrixConnectionData *conn,
     return fetch_data;
 }
 
+/**
+ * Returns the userid for our access token, mostly as a check our token
+ * is valid.
+ */
+MatrixApiRequestData *matrix_api_whoami(MatrixConnectionData *conn,
+        MatrixApiCallback callback,
+        MatrixApiErrorCallback error_callback,
+        MatrixApiBadResponseCallback bad_response_callback,
+        gpointer user_data)
+{
+    GString *url;
+    MatrixApiRequestData *fetch_data;
+
+    url = g_string_new(conn->homeserver);
+    g_string_append_printf(url,
+            "_matrix/client/r0/account/whoami?access_token=%s",
+            purple_url_encode(conn->access_token));
+
+    fetch_data = matrix_api_start(url->str, "GET", NULL, conn, callback,
+            error_callback, bad_response_callback, user_data, 10*1024);
+    g_string_free(url, TRUE);
+
+    return fetch_data;
+}
+
 MatrixApiRequestData *matrix_api_upload_keys(MatrixConnectionData *conn,
         JsonObject *device_keys, JsonObject *one_time_keys,
         MatrixApiCallback callback,

--- a/matrix-api.c
+++ b/matrix-api.c
@@ -1074,7 +1074,7 @@ MatrixApiRequestData *matrix_api_upload_keys(MatrixConnectionData *conn,
     fetch_data = matrix_api_start_full(url->str, "POST",
             "Content-Type: application/json", json, NULL, 0,
             conn, callback, error_callback, bad_response_callback,
-            user_data, 1024);
+            user_data, 10*1024);
     g_free(json);
     g_string_free(url, TRUE);
 

--- a/matrix-api.c
+++ b/matrix-api.c
@@ -601,14 +601,20 @@ void matrix_api_cancel(MatrixApiRequestData *data)
 
 gchar *_build_login_body(const gchar *username, const gchar *password, const gchar *device_id)
 {
-    JsonObject *body;
+    JsonObject *body, *ident;
     JsonNode *node;
     JsonGenerator *generator;
     gchar *result;
 
     body = json_object_new();
     json_object_set_string_member(body, "type", "m.login.password");
-    json_object_set_string_member(body, "user", username);
+
+    ident = json_object_new();
+    /* TODO: Support 3pid rather than username */
+    json_object_set_string_member(ident, "type", "m.id.user");
+    json_object_set_string_member(ident, "user", username);
+    json_object_set_object_member(body, "identifier", ident);
+
     json_object_set_string_member(body, "password", password);
     json_object_set_string_member(body, "initial_device_display_name", "purple-matrix");
     if (device_id != NULL)
@@ -638,9 +644,7 @@ MatrixApiRequestData *matrix_api_password_login(MatrixConnectionData *conn,
 
     purple_debug_info("matrixprpl", "logging in %s\n", username);
 
-    // As per https://github.com/matrix-org/synapse/pull/459, synapse
-    // didn't expose login at 'r0'.
-    url = g_strconcat(conn->homeserver, "_matrix/client/api/v1/login",
+    url = g_strconcat(conn->homeserver, "_matrix/client/r0/login",
             NULL);
 
     json = _build_login_body(username, password, device_id);

--- a/matrix-api.h
+++ b/matrix-api.h
@@ -363,6 +363,27 @@ MatrixApiRequestData *matrix_api_download_thumb(MatrixConnectionData *conn,
         gpointer user_data);
 
 /**
+ * Returns the userid for our access token, mostly as a check our token
+ * is valid.
+ *
+ * @param conn             The connection with which to make the request
+ * @param callback         Function to be called when the request completes
+ * @param error_callback   Function to be called if there is an error making
+ *                             the request. If NULL, matrix_api_error will be
+ *                             used.
+ * @param bad_response_callback Function to be called if the API gives a non-200
+ *                            response. If NULL, matrix_api_bad_response will be
+ *                            used.
+ * @param user_data        Opaque data to be passed to the callbacks
+ *
+ */
+MatrixApiRequestData *matrix_api_whoami(MatrixConnectionData *conn,
+        MatrixApiCallback callback,
+        MatrixApiErrorCallback error_callback,
+        MatrixApiBadResponseCallback bad_response_callback,
+        gpointer user_data);
+
+/**
  * e2e: Upload keys; one or more of the device keys and the one time keys
  * @param conn             The connection with which to make the request
  * @param device_keys      (optional) Json Object with the signed device keys

--- a/matrix-connection.c
+++ b/matrix-connection.c
@@ -186,6 +186,8 @@ static void _login_completed(MatrixConnectionData *conn,
             "user_id"));
     device_id = matrix_json_object_get_string_member(root_obj, "device_id");
     purple_account_set_string(pc->account, "device_id", device_id);
+    purple_account_set_string(pc->account, PRPL_ACCOUNT_OPT_ACCESS_TOKEN,
+            access_token);
 
     if (device_id) {
         matrix_e2e_get_device_keys(conn, device_id);


### PR DESCRIPTION
This actually should be split, but it's all login related.
Firstly avoid the r0 login API (issue #100)
Also, start storing access tokens instead/as well as passwords.
This way, if you have a valuable password (e.g. a matrix server wired to corporate login) then if you don't tick 'save password' then we still have the access token saved and can use that next time.