### PR TITLE
matrix-connection: Only change state and progress if we're not already connected

### DIFF
--- a/matrix-connection.c
+++ b/matrix-connection.c
@@ -122,8 +122,11 @@ static void _sync_complete(MatrixConnectionData *ma, gpointer user_data,
         return;
     }
 
-    purple_connection_update_progress(pc, _("Connected"), 2, 3);
-    purple_connection_set_state(pc, PURPLE_CONNECTED);
+    // Only update progress and set state if we're not already connected
+    if (purple_connection_get_state(pc) != PURPLE_CONNECTED) {
+        purple_connection_update_progress(pc, _("Connected"), 2, 3);
+        purple_connection_set_state(pc, PURPLE_CONNECTED);
+    }
 
     matrix_sync_parse(pc, body, &next_batch);
 


### PR DESCRIPTION
This PR fixes #31 by only setting the progress (which is what causes spam on bitlbee) and state when our state isn't already "PURPLE_CONNECTED".

![](https://elixi.re/i/7g99xd8c.png)

Signed-off-by: Arda Ozkal <githubpublic@ave.zone>