### PR TITLE
matrix-api: use a non-fatal error code on HTTP 429 and >500

### DIFF
--- a/matrix-api.c
+++ b/matrix-api.c
@@ -81,8 +81,14 @@ void matrix_api_bad_response(MatrixConnectionData *ma, gpointer user_data,
                 _("Error from home server"), http_response_code);
     }
 
+    PurpleConnectionError error_reason = PURPLE_CONNECTION_ERROR_OTHER_ERROR;
+
+    if (http_response_code == 429 || http_response_code > 500) {
+        error_reason = PURPLE_CONNECTION_ERROR_NETWORK_ERROR;
+    }
+
     purple_connection_error_reason(ma->pc,
-            PURPLE_CONNECTION_ERROR_OTHER_ERROR,
+            error_reason,
             error_message);
 
     g_free(error_message);

--- a/matrix-api.c
+++ b/matrix-api.c
@@ -66,6 +66,7 @@ void matrix_api_bad_response(MatrixConnectionData *ma, gpointer user_data,
     JsonObject *json_obj;
     const gchar *errcode = NULL, *error = NULL;
     gchar *error_message;
+    PurpleConnectionError error_reason = PURPLE_CONNECTION_ERROR_OTHER_ERROR;
 
     if(json_root != NULL) {
         json_obj = matrix_json_node_get_object(json_root);
@@ -81,8 +82,7 @@ void matrix_api_bad_response(MatrixConnectionData *ma, gpointer user_data,
                 _("Error from home server"), http_response_code);
     }
 
-    PurpleConnectionError error_reason = PURPLE_CONNECTION_ERROR_OTHER_ERROR;
-
+    /* Use a non-fatal error reason on HTTP 429 and 500 to allow auto-reconnection */
     if (http_response_code == 429 || http_response_code > 500) {
         error_reason = PURPLE_CONNECTION_ERROR_NETWORK_ERROR;
     }


### PR DESCRIPTION
Currently, this library exits with [`PURPLE_CONNECTION_ERROR_OTHER_ERROR`](https://docs.pidgin.im/pidgin/2.x.y/connection_8h.html#ad073b7b1d65488a3b3e39fc382324c4dac75515e26e28365555ad227717317ffa) whenever there's an error.

This is an exit reason that causes `wants_to_die` to be set to `true` ([see here](https://docs.pidgin.im/pidgin/2.x.y/connection_8h.html#a116f2baf977af61aaa788e578f8b1646)).

This, in turn, causes bitlbee to not try to automatically reconnect.

---

This PR adds a check to exit with `PURPLE_CONNECTION_ERROR_NETWORK_ERROR` instead when the reason for exiting are HTTP error code 429, or any code above 500. This error reason sets `wants_to_die` to `false`.

This allows bitlbee to automatically reconnect:

![](https://elixi.re/i/yw3mhi5e.png)


---

Signed-off-by: Arda Ozkal <githubpublic@ave.zone>