### PR TITLE
Build failure workaround: _on_typing

### DIFF
--- a/matrix-room.c
+++ b/matrix-room.c
@@ -210,6 +210,7 @@ static void _on_typing(PurpleConversation *conv,
         old_user_ids = matrix_json_object_get_array_member(old_state->content, "user_ids");
         old_len = json_array_get_length(old_user_ids);
     } else {
+	old_user_ids = NULL; /* Work around gcc 10.3.1 false uninit warn */
         old_len = 0;
     }
     


### PR DESCRIPTION
We have a report of gcc not liking old_user_ids being unitialised;
but as far as I can tell it doesn't matter when old_len is set to 0
because the loop won't happen.

Set it to NULL and hope it placates gcc.

Fixes: 108

Signed-off-by: Dr. David Alan Gilbert <dave@treblig.org>