### PR TITLE
Allow new room creation

### DIFF
--- a/matrix-api.h
+++ b/matrix-api.h
@@ -236,6 +236,14 @@ MatrixApiRequestData *matrix_api_join_room(MatrixConnectionData *conn,
         MatrixApiBadResponseCallback bad_response_callback,
         gpointer user_data);
 
+
+MatrixApiRequestData *matrix_api_create_room(MatrixConnectionData *conn,
+        const gchar *room,
+        MatrixApiCallback callback,
+        MatrixApiErrorCallback error_callback,
+        MatrixApiBadResponseCallback bad_response_callback,
+        gpointer user_data);
+
 /**
  * Sends a typing notifiaction to a room
  *

--- a/matrix-connection.c
+++ b/matrix-connection.c
@@ -418,10 +418,20 @@ static void _join_failed(MatrixConnectionData *conn,
     JsonObject *json_obj;
     const gchar *error = NULL;
     const gchar *title = "Error joining chat";
+    const gchar *code = NULL;
 
     if (json_root != NULL) {
         json_obj = matrix_json_node_get_object(json_root);
         error = matrix_json_object_get_string_member(json_obj, "error");
+        code = matrix_json_object_get_string_member(json_obj, "errcode");
+    }
+
+    if (strcmp(code, "M_NOT_FOUND") == 0) { // alias is free. create room.
+        const char *room_id_chat = g_hash_table_lookup(components, PRPL_CHAT_INFO_ROOM_ID);
+        if (room_id_chat != 0 && room_id_chat[0] == '#') {
+            matrix_api_create_room(conn, room_id_chat, _join_completed, _join_error, _join_failed, components);
+            return;
+        }
     }
 
     purple_notify_error(conn->pc, title, title, error);


### PR DESCRIPTION
Purple allows to create chat entry before connection to matrix server. But matrix does not allow us to know new rooms id before it is created.

As result we do not know difference between matrix room join or room created by the user.

More over: createRoom Matrix API call result happens after matrix room id pushed to the client.

As result pidgin does not know if new room is user created or server created.

To solve this, we have to prevent sync event happens before we receive result code from /createRoom API call and update room id for pidgin chat buddy.

Works better with #127 pull request.