### PR TITLE
Sync crash fix

### DIFF
--- a/matrix-api.c
+++ b/matrix-api.c
@@ -52,7 +52,7 @@ void matrix_api_error(MatrixConnectionData *conn, gpointer user_data,
         const gchar *error_message)
 {
     if(strcmp(error_message, "cancelled") != 0)
-        purple_connection_error_reason(conn->pc,
+        purple_connection_error_reason(conn->pc->gc,
             PURPLE_CONNECTION_ERROR_NETWORK_ERROR, error_message);
 }
 
@@ -87,7 +87,7 @@ void matrix_api_bad_response(MatrixConnectionData *ma, gpointer user_data,
         error_reason = PURPLE_CONNECTION_ERROR_NETWORK_ERROR;
     }
 
-    purple_connection_error_reason(ma->pc,
+    purple_connection_error_reason(ma->pc->gc,
             error_reason,
             error_message);
 
@@ -531,7 +531,7 @@ static MatrixApiRequestData *matrix_api_start_full(const gchar *url,
     }
 #endif
 
-    request = _build_request(conn->pc->account, url, method, extra_headers,
+    request = _build_request(conn->pc, url, method, extra_headers,
                              body, extra_data, extra_len);
 
     if(purple_debug_is_unsafe())
@@ -547,13 +547,13 @@ static MatrixApiRequestData *matrix_api_start_full(const gchar *url,
 
 #if PURPLE_VERSION_CHECK(2,11,0)
     purple_data = purple_util_fetch_url_request_data_len_with_account(
-            conn -> pc -> account,
+            conn -> pc,
             url, FALSE, NULL, TRUE, request->str, request->len,
             TRUE, max_len, matrix_api_complete,
             data);
 #else
     purple_data = purple_util_fetch_url_request_len_with_account(
-            conn -> pc -> account,
+            conn -> pc,
             url, FALSE, NULL, TRUE, request->str, TRUE,
             max_len, matrix_api_complete,
             data);
@@ -691,7 +691,7 @@ MatrixApiRequestData *matrix_api_sync(MatrixConnectionData *conn,
         g_string_append(url, "&full_state=true");
 
     purple_debug_info("matrixprpl", "syncing %s since %s (full_state=%i)\n",
-                conn->pc->account->username, since, full_state);
+                conn->pc->username, since, full_state);
 
     /* XXX: stream the response, so that we don't need to allocate so much
      * memory? But it's JSON

--- a/matrix-connection.c
+++ b/matrix-connection.c
@@ -45,7 +45,7 @@ void matrix_connection_new(PurpleConnection *pc)
 
      g_assert(purple_connection_get_protocol_data(pc) == NULL);
      conn = g_new0(MatrixConnectionData, 1);
-     conn->pc = pc;
+     conn->pc = pc->account;
      purple_connection_set_protocol_data(pc, conn);
 }
 
@@ -111,7 +111,7 @@ static void _sync_complete(MatrixConnectionData *ma, gpointer user_data,
     JsonNode *body,
     const char *raw_body, size_t raw_body_len, const char *content_type)
 {
-    PurpleConnection *pc = ma->pc;
+    PurpleConnection *pc = ma->pc->gc;
     const gchar *next_batch;
 
     ma->active_sync = NULL;
@@ -166,7 +166,7 @@ static gboolean _account_has_active_conversations(PurpleAccount *account)
 
 static void _start_sync(MatrixConnectionData *conn)
 {
-    PurpleConnection *pc = conn->pc;
+    PurpleConnection *pc = conn->pc->gc;
     gboolean needs_full_state_sync = TRUE;
     const gchar *next_batch;
     const gchar *device_id = purple_account_get_string(pc->account,
@@ -214,7 +214,7 @@ static void _login_completed(MatrixConnectionData *conn,
         JsonNode *json_root,
         const char *raw_body, size_t raw_body_len, const char *content_type)
 {
-    PurpleConnection *pc = conn->pc;
+    PurpleConnection *pc = conn->pc->gc;
     JsonObject *root_obj;
     const gchar *access_token;
     const gchar *device_id;
@@ -307,7 +307,7 @@ static void _password_login(MatrixConnectionData *conn, PurpleAccount *acct)
                 _login_completed, conn);
     } else {
         purple_account_request_password(acct,G_CALLBACK( _password_received),
-                G_CALLBACK(_password_cancel), conn->pc);
+                G_CALLBACK(_password_cancel), conn->pc->gc);
     }
 }
 
@@ -424,8 +424,8 @@ static void _join_failed(MatrixConnectionData *conn,
         error = matrix_json_object_get_string_member(json_obj, "error");
     }
 
-    purple_notify_error(conn->pc, title, title, error);
-    purple_serv_got_join_chat_failed(conn->pc, components);
+    purple_notify_error(conn->pc->gc, title, title, error);
+    purple_serv_got_join_chat_failed(conn->pc->gc, components);
     g_hash_table_destroy(components);
 }
 

--- a/matrix-connection.h
+++ b/matrix-connection.h
@@ -29,10 +29,11 @@
 #include <glib.h>
 
 struct _PurpleConnection;
+struct _PurpleAccount;
 struct _MatrixE2EData;
 
 typedef struct _MatrixConnectionData {
-    struct _PurpleConnection *pc;
+    struct _PurpleAccount *pc;
     gchar *homeserver;      /* URL of the homeserver. Always ends in '/' */
     gchar *user_id;         /* our full user id ("@user:server") */
     gchar *access_token;    /* access token corresponding to our user */

--- a/matrix-e2e.h
+++ b/matrix-e2e.h
@@ -36,6 +36,6 @@ gboolean matrix_e2e_parse_media_decrypt_info(MatrixMediaCryptInfo **crypt,
                                              JsonObject *file_obj);
 const char *matrix_e2e_decrypt_media(MatrixMediaCryptInfo *crypt,
                                      size_t inlen, const void *in, void **out);
-void matrix_e2e_handle_sync_key_counts(struct _PurpleConnection *pc, struct _JsonObject *count_object, gboolean force_send);
+void matrix_e2e_handle_sync_key_counts(struct _MatrixConnectionData *pc, struct _JsonObject *count_object, gboolean force_send);
 
 #endif

--- a/matrix-sync.c
+++ b/matrix-sync.c
@@ -334,7 +334,8 @@ void matrix_sync_parse(PurpleConnection *pc, JsonNode *body,
     JsonObject *dev_key_counts = matrix_json_object_get_object_member(rootObj,
                                     "device_one_time_keys_count");
     if (dev_key_counts) {
-	      matrix_e2e_handle_sync_key_counts(pc, dev_key_counts, FALSE);
+	      MatrixConnectionData *conn = purple_connection_get_protocol_data(pc);
+	      matrix_e2e_handle_sync_key_counts(conn, dev_key_counts, FALSE);
     }
 
     /* Now go round the rooms again getting the timeline events */


### PR DESCRIPTION
Since PurpleConnection is temporary object, it can be freed by purple client. It happens at least when account manually disconnected and reconnected.

Storing this pointer inside MatrixConnectionData makes it possible for sync related #125  crashes.

For all long duration operations use PurpleAccount -> PurpleConnection pointer, which will be updated on reconnect.

EDIT: We need to replace all PurpleConnection with MatrixConnectionData pointers where it is possible. For patch simplicity I replace only necessary calls.

EDIT: Maybe as additional checks we going need to call conn->pc->gc != null and PURPLE_CONNECTION_IS_CONNECTED()